### PR TITLE
PHP 7.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ sudo: false
 php:
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
   - nightly
 
 matrix:

--- a/src/EmojiModifier.php
+++ b/src/EmojiModifier.php
@@ -2676,7 +2676,7 @@ class EmojiModifier
 
         $len = strlen($str);
         for($i = 0; $i < $len; $i++) {
-            $in = ord($str{$i});
+            $in = ord($str[$i]);
             if (0 == $mState) {
                 // When mState is zero we expect either a US-ASCII character or a
                 // multi-octet sequence.


### PR DESCRIPTION
PHP 7.4 deprecated the `$arr{$key}` syntax, and requires it to be `$arr[$key]`. 

This PR fixes that, and adds PHP 7.2, 7.3 and 7.4 to Travis CI, since those are more current.